### PR TITLE
feat!: Change behavior of ready functions to ignore errors

### DIFF
--- a/resources/deployment/ready.go
+++ b/resources/deployment/ready.go
@@ -6,7 +6,6 @@ package deployment
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -15,10 +14,15 @@ import (
 
 // IsDeploymentAvailable determines if the available condition of a deployment
 // is fulfilled.
+// It assumes that failure to get a deployment is not an error, since the
+// deployment might not have been created yet, which just means that it is not
+// available yet.
+// This means that any other errors related to kubernetes API access are also 
+// ignored.
 func IsDeploymentAvailable(ctx context.Context, kube klient.Client, name, namespace string) (bool, error) {
 	deploy := appsv1.Deployment{}
 	if err := klient.Get(ctx, kube, name, namespace, &deploy); err != nil {
-		return false, errors.Wrap(err, "cannot get deployment")
+		return false, nil
 	}
 	for _, c := range deploy.Status.Conditions {
 		if c.Type == appsv1.DeploymentAvailable {

--- a/resources/ingress/ready.go
+++ b/resources/ingress/ready.go
@@ -6,17 +6,21 @@ package ingress
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	networkingv1 "k8s.io/api/networking/v1"
 
 	"github.com/dbinfrago/kubernetes-e2e-test-framework/klient"
 )
 
 // IsALBAvailable determines if the latest ingress provisioned load balancer is available based on desired number of LBs.
+// It assumes that failure to get a ingress is not an error, since the ingress
+// might not have been created yet, which just means that it is not available
+// yet.
+// This means that any other errors related to kubernetes API access are also 
+// ignored.
 func IsALBAvailable(ctx context.Context, kube klient.Client, desiredNumberOfAlbs int, name, namespace string) (bool, *networkingv1.Ingress, error) {
 	ingress := &networkingv1.Ingress{}
 	if err := klient.Get(ctx, kube, name, namespace, ingress); err != nil {
-		return false, ingress, errors.Wrap(err, "cannot get ingress")
+		return false, ingress, nil
 	}
 	return len(ingress.Status.LoadBalancer.Ingress) == desiredNumberOfAlbs && ingress.Status.LoadBalancer.Ingress[desiredNumberOfAlbs-1].Hostname != "", ingress, nil
 }

--- a/resources/pod/ready.go
+++ b/resources/pod/ready.go
@@ -6,17 +6,20 @@ package pod
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/dbinfrago/kubernetes-e2e-test-framework/klient"
 )
 
 // IsPodAvailable determines if the available condition of a pod is fulfilled.
+// It assumes that failure to get a pod is not an error, since the pod might not
+// have been created yet, which just means that it is not available yet.
+// This means that any other errors related to kubernetes API access are also 
+// ignored.
 func IsPodAvailable(ctx context.Context, kube klient.Client, name, namespace string) (bool, error) {
 	pod := corev1.Pod{}
 	if err := klient.Get(ctx, kube, name, namespace, &pod); err != nil {
-		return false, errors.Wrap(err, "cannot get pod")
+		return false, nil
 	}
 	for _, c := range pod.Status.Conditions {
 		if c.Type == corev1.ContainersReady {

--- a/resources/pvc/ready.go
+++ b/resources/pvc/ready.go
@@ -6,7 +6,6 @@ package pvc
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,16 +15,24 @@ import (
 )
 
 // IsPersistentVolumeClaimStatus checks if PVC has specified status
+// It assumes that failure to get a pvc is not an error, since the pvc might not
+// have been created yet, which just means that it is not available yet.
+// This means that any other errors related to kubernetes API access are also 
+// ignored.
 func IsPersistentVolumeClaimStatus(ctx context.Context, kube klient.Client, pvcStatus corev1.PersistentVolumeClaimPhase, name, namespace string) (bool, error) {
 	pvc := &corev1.PersistentVolumeClaim{}
 	if err := klient.Get(ctx, kube, name, namespace, pvc); err != nil {
-		return false, errors.Wrap(err, "cannot get persistentvolumeclaim")
+		return false, nil
 	}
 	return pvc.Status.Phase == pvcStatus, nil
 }
 
 // IsPersistentVolumeVolumeModificationSuccessful checks PVC-related events to see if VolumeModification via
 // Volumemodifier was successful
+// It assumes that failure to get a pvc is not an error, since the pvc might not
+// have been created yet, which just means that it is not available yet.
+// This means that any other errors related to kubernetes API access are also 
+// ignored.
 //
 // Cf: https://github.com/torredil/volume-modifier-for-k8s/blob/5eb7d23f72d688ae0b7d9db8019d3371f4e93289/pkg/controller/controller.go#L288
 // https://aws.amazon.com/de/blogs/storage/simplifying-amazon-ebs-volume-migration-and-modification-using-the-ebs-csi-driver/
@@ -36,7 +43,7 @@ func IsPersistentVolumeVolumeModificationSuccessful(ctx context.Context, kube kl
 		return kubeClient.List(ctx, events, client.InNamespace(namespace), client.MatchingFields{"involvedObject.name": name})
 	})
 	if err != nil {
-		return false, errors.Wrap(err, "cannot get events for persistentvolumeclaim")
+		return false, nil
 	}
 	for _, item := range events.Items {
 		if item.Reason == "VolumeModificationSuccessful" {


### PR DESCRIPTION
These functions are intended for use in WaitFor callbacks. As such, they should assume that the object they are checking will eventually exist and failure to find it is only temporary.

It's technically a breaking change, but I think for most uses it will rather be a fix with no immediately noticable difference.